### PR TITLE
Use containerView height instead of UIScreen height

### DIFF
--- a/BottomPopup/BottomPopupController/BottomPopupPresentationController.swift
+++ b/BottomPopup/BottomPopupController/BottomPopupPresentationController.swift
@@ -14,7 +14,7 @@ final class BottomPopupPresentationController: UIPresentationController {
     
     override var frameOfPresentedViewInContainerView: CGRect {
         get {
-            return CGRect(origin: CGPoint(x: 0, y: UIScreen.main.bounds.size.height - attributesDelegate.popupHeight), size: CGSize(width: presentedViewController.view.frame.size.width, height: attributesDelegate.popupHeight))
+            return CGRect(origin: CGPoint(x: 0, y: containerView!.bounds.size.height - attributesDelegate.popupHeight), size: CGSize(width: presentedViewController.view.frame.size.width, height: attributesDelegate.popupHeight))
         }
     }
     


### PR DESCRIPTION
this helps position the popup correctly in the iPad's split screen mode