### PR TITLE
fix memory leak

### DIFF
--- a/BottomPopup.podspec
+++ b/BottomPopup.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "BottomPopup"
-  s.version      = "0.7.0"
+  s.version      = "0.7.1"
   s.summary      = "BottomPopup provides a popup-like presentation style to any view controller"
 
   s.homepage     = "https://github.com/ergunemr/BottomPopup"

--- a/BottomPopup/BottomPopupController/BottomPopupDismissAnimator.swift
+++ b/BottomPopup/BottomPopupController/BottomPopupDismissAnimator.swift
@@ -16,7 +16,7 @@ final class BottomPopupDismissAnimator: NSObject, UIViewControllerAnimatedTransi
     }
     
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        return attributesOwner.popupDismissDuration
+        attributesOwner.popupDismissDuration
     }
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {

--- a/BottomPopup/BottomPopupController/BottomPopupDismissInteractionController.swift
+++ b/BottomPopup/BottomPopupController/BottomPopupDismissInteractionController.swift
@@ -13,29 +13,29 @@ protocol BottomPopupDismissInteractionControllerDelegate: class {
 }
 
 final class BottomPopupDismissInteractionController: UIPercentDrivenInteractiveTransition {
-    private let kMinPercentOfVisiblePartToCompleteAnimation = CGFloat(0.5)
-    private let kSwipeDownThreshold = CGFloat(1000)
     private weak var presentedViewController: BottomPresentableViewController?
+    private weak var delegate: BottomPopupDismissInteractionControllerDelegate?
     private weak var transitioningDelegate: BottomPopupTransitionHandler?
     private unowned var attributesDelegate: BottomPopupAttributesDelegate
-    weak var delegate: BottomPopupDismissInteractionControllerDelegate?
-    
+    private (set) var isInteractiveDismissStarted: Bool = false
+
     private var currentPercent: CGFloat = 0 {
         didSet {
             delegate?.dismissInteractionPercentChanged(from: oldValue, to: currentPercent)
         }
     }
     
-    init(presentedViewController: BottomPresentableViewController?, attributesDelegate: BottomPopupAttributesDelegate) {
+    init(presentedViewController: BottomPresentableViewController?, delegate: BottomPopupDismissInteractionControllerDelegate?, attributesDelegate: BottomPopupAttributesDelegate) {
         self.presentedViewController = presentedViewController
         self.transitioningDelegate = presentedViewController?.transitioningDelegate as? BottomPopupTransitionHandler
+        self.delegate = delegate
         self.attributesDelegate = attributesDelegate
         super.init()
         preparePanGesture(in: presentedViewController?.view)
     }
     
     private func finishAnimation(withVelocity velocity: CGPoint) {
-        if currentPercent > kMinPercentOfVisiblePartToCompleteAnimation || velocity.y > kSwipeDownThreshold {
+        if currentPercent > BottomPopupConstants.minPercentOfVisiblePartToCompleteAnimation || velocity.y > BottomPopupConstants.swipeDownThreshold {
             finish()
         } else {
             cancel()
@@ -55,13 +55,13 @@ final class BottomPopupDismissInteractionController: UIPercentDrivenInteractiveT
         
         switch pan.state {
         case .began:
-            transitioningDelegate?.isInteractiveDismissStarted = true
+            isInteractiveDismissStarted = true
             presentedViewController?.dismiss(animated: true, completion: nil)
         case .changed:
             update(currentPercent)
         default:
             let velocity = pan.velocity(in: presentedViewController?.view)
-            transitioningDelegate?.isInteractiveDismissStarted = false
+            isInteractiveDismissStarted = false
             finishAnimation(withVelocity: velocity)
         }
     }

--- a/BottomPopup/BottomPopupController/BottomPopupNavigationController.swift
+++ b/BottomPopup/BottomPopupController/BottomPopupNavigationController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 open class BottomPopupNavigationController: UINavigationController, BottomPopupAttributesDelegate {
-    
     private var transitionHandler: BottomPopupTransitionHandler?
     open weak var popupDelegate: BottomPopupDelegate?
     
@@ -29,8 +28,7 @@ open class BottomPopupNavigationController: UINavigationController, BottomPopupA
     
     open override func viewDidLoad() {
         super.viewDidLoad()
-        
-        transitionHandler?.notifyViewLoaded(withPopupDelegate: popupDelegate)
+        transitionHandler?.notifyViewLoaded()
         popupDelegate?.bottomPopupViewLoaded()
         self.view.accessibilityIdentifier = popupViewAccessibilityIdentifier
     }
@@ -63,7 +61,7 @@ open class BottomPopupNavigationController: UINavigationController, BottomPopupA
     //MARK: Private Methods
     
     private func initialize() {
-        transitionHandler = BottomPopupTransitionHandler(popupViewController: self)
+        transitionHandler = BottomPopupTransitionHandler(popupViewController: self, popupDelegate: popupDelegate)
         transitioningDelegate = transitionHandler
         modalPresentationStyle = .custom
     }
@@ -76,23 +74,15 @@ open class BottomPopupNavigationController: UINavigationController, BottomPopupA
         self.view.layer.mask = maskLayer
     }
     
-    //MARK: BottomPopupAttributesDelegate Variables
-    
-    open var popupHeight: CGFloat { return BottomPopupConstants.kDefaultHeight }
-    
-    open var popupTopCornerRadius: CGFloat { return BottomPopupConstants.kDefaultTopCornerRadius }
-    
-    open var popupPresentDuration: Double { return BottomPopupConstants.kDefaultPresentDuration }
-    
-    open var popupDismissDuration: Double { return BottomPopupConstants.kDefaultDismissDuration }
-    
-    open var popupShouldDismissInteractivelty: Bool { return BottomPopupConstants.dismissInteractively }
-    
-    open var popupDimmingViewAlpha: CGFloat { return BottomPopupConstants.kDimmingViewDefaultAlphaValue }
-    
-    open var popupShouldBeganDismiss: Bool { return BottomPopupConstants.shouldBeganDismiss }
-    
-    open var popupViewAccessibilityIdentifier: String { return BottomPopupConstants.defaultPopupViewAccessibilityIdentifier }
+    // MARK: - BottomPopupAttributesDelegate Variables
+    open var popupHeight: CGFloat { BottomPopupConstants.defaultHeight }
+    open var popupTopCornerRadius: CGFloat { BottomPopupConstants.defaultTopCornerRadius }
+    open var popupPresentDuration: Double { BottomPopupConstants.defaultPresentDuration }
+    open var popupDismissDuration: Double { BottomPopupConstants.defaultDismissDuration }
+    open var popupShouldDismissInteractivelty: Bool { BottomPopupConstants.dismissInteractively }
+    open var popupDimmingViewAlpha: CGFloat { BottomPopupConstants.dimmingViewDefaultAlphaValue }
+    open var popupShouldBeganDismiss: Bool { BottomPopupConstants.shouldBeganDismiss }
+    open var popupViewAccessibilityIdentifier: String { BottomPopupConstants.defaultPopupViewAccessibilityIdentifier }
 }
 
 extension BottomPopupNavigationController {

--- a/BottomPopup/BottomPopupController/BottomPopupPresentAnimator.swift
+++ b/BottomPopup/BottomPopupController/BottomPopupPresentAnimator.swift
@@ -16,7 +16,7 @@ final class BottomPopupPresentAnimator: NSObject, UIViewControllerAnimatedTransi
     }
     
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        return attributesOwner.popupPresentDuration
+        attributesOwner.popupPresentDuration
     }
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {

--- a/BottomPopup/BottomPopupController/BottomPopupPresentationController.swift
+++ b/BottomPopup/BottomPopupController/BottomPopupPresentationController.swift
@@ -14,9 +14,7 @@ final class BottomPopupPresentationController: UIPresentationController {
     private unowned var attributesDelegate: BottomPopupAttributesDelegate
     
     override var frameOfPresentedViewInContainerView: CGRect {
-        get {
-            return CGRect(origin: CGPoint(x: 0, y: UIScreen.main.bounds.size.height - popupHeight), size: CGSize(width: presentedViewController.view.frame.size.width, height: popupHeight))
-        }
+        CGRect(origin: CGPoint(x: 0, y: UIScreen.main.bounds.size.height - popupHeight), size: CGSize(width: presentedViewController.view.frame.size.width, height: popupHeight))
     }
     
     private func changeDimmingViewAlphaAlongWithAnimation(to alpha: CGFloat) {
@@ -49,6 +47,13 @@ final class BottomPopupPresentationController: UIPresentationController {
     override func dismissalTransitionWillBegin() {
         changeDimmingViewAlphaAlongWithAnimation(to: 0)
     }
+
+    func setHeight(to height: CGFloat) {
+        popupHeight = height
+        UIView.animate(withDuration: attributesDelegate.popupPresentDuration) {
+            self.containerViewWillLayoutSubviews()
+        }
+    }
     
     @objc private func handleTap(_ tap: UITapGestureRecognizer) {
         guard attributesDelegate.popupShouldBeganDismiss else { return }
@@ -73,12 +78,3 @@ private extension BottomPopupPresentationController {
         [tapGesture, swipeGesture].forEach { dimmingView.addGestureRecognizer($0) }
     }
 }
-
-extension BottomPopupPresentationController {
-     func setHeight(to height: CGFloat) {
-        popupHeight = height
-        UIView.animate(withDuration: attributesDelegate.popupPresentDuration) {
-            self.containerViewWillLayoutSubviews()
-        }
-     }
- }

--- a/BottomPopup/BottomPopupController/BottomPopupUtils.swift
+++ b/BottomPopup/BottomPopupController/BottomPopupUtils.swift
@@ -39,13 +39,15 @@ public protocol BottomPopupAttributesDelegate: class {
     var popupViewAccessibilityIdentifier: String { get }
 }
 
-public struct BottomPopupConstants {
-    static let kDefaultHeight: CGFloat = 377.0
-    static let kDefaultTopCornerRadius: CGFloat = 10.0
-    static let kDefaultPresentDuration = 0.5
-    static let kDefaultDismissDuration = 0.5
+public enum BottomPopupConstants {
+    static let minPercentOfVisiblePartToCompleteAnimation: CGFloat = 0.5
+    static let swipeDownThreshold: CGFloat = 1000
+    static let defaultHeight: CGFloat = 377.0
+    static let defaultTopCornerRadius: CGFloat = 10.0
+    static let defaultPresentDuration = 0.5
+    static let defaultDismissDuration = 0.5
     static let dismissInteractively = true
     static let shouldBeganDismiss = true
-    static let kDimmingViewDefaultAlphaValue: CGFloat = 0.5
+    static let dimmingViewDefaultAlphaValue: CGFloat = 0.5
     static let defaultPopupViewAccessibilityIdentifier: String = "bottomPopupView"
 }

--- a/BottomPopup/BottomPopupController/BottomPopupViewController.swift
+++ b/BottomPopup/BottomPopupController/BottomPopupViewController.swift
@@ -16,86 +16,69 @@ open class BottomPopupViewController: UIViewController, BottomPopupAttributesDel
     
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        
         initialize()
     }
     
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        
         initialize()
     }
     
     open override func viewDidLoad() {
-        
         super.viewDidLoad()
-        transitionHandler?.notifyViewLoaded(withPopupDelegate: popupDelegate)
+        transitionHandler?.notifyViewLoaded()
         popupDelegate?.bottomPopupViewLoaded()
-        self.view.accessibilityIdentifier = popupViewAccessibilityIdentifier
+        view.accessibilityIdentifier = popupViewAccessibilityIdentifier
     }
     
     open override  func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
         curveTopCorners()
         popupDelegate?.bottomPopupWillAppear()
     }
     
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
         popupDelegate?.bottomPopupDidAppear()
     }
     
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        
         popupDelegate?.bottomPopupWillDismiss()
     }
     
     open override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        
         popupDelegate?.bottomPopupDidDismiss()
     }
+
+    // MARK: - Public Methods
+    open func updatePopupHeight(to height: CGFloat) {
+        transitionHandler?.setHeight(to: height)
+    }
     
-    //MARK: Private Methods
-    
+    // MARK: Private Methods
     private func initialize() {
-        transitionHandler = BottomPopupTransitionHandler(popupViewController: self)
+        transitionHandler = BottomPopupTransitionHandler(popupViewController: self, popupDelegate: popupDelegate)
         transitioningDelegate = transitionHandler
         modalPresentationStyle = .custom
     }
     
     private func curveTopCorners() {
-        let path = UIBezierPath(roundedRect: self.view.bounds, byRoundingCorners: [.topLeft, .topRight], cornerRadii: CGSize(width: popupTopCornerRadius, height: 0))
+        let path = UIBezierPath(roundedRect: view.bounds, byRoundingCorners: [.topLeft, .topRight], cornerRadii: CGSize(width: popupTopCornerRadius, height: 0))
         let maskLayer = CAShapeLayer()
-        maskLayer.frame = self.view.bounds
+        maskLayer.frame = view.bounds
         maskLayer.path = path.cgPath
-        self.view.layer.mask = maskLayer
+        view.layer.mask = maskLayer
     }
     
-    //MARK: BottomPopupAttributesDelegate Variables
-    
-    open var popupHeight: CGFloat { return BottomPopupConstants.kDefaultHeight }
-    
-    open var popupTopCornerRadius: CGFloat { return BottomPopupConstants.kDefaultTopCornerRadius }
-    
-    open var popupPresentDuration: Double { return BottomPopupConstants.kDefaultPresentDuration }
-    
-    open var popupDismissDuration: Double { return BottomPopupConstants.kDefaultDismissDuration }
-    
-    open var popupShouldDismissInteractivelty: Bool { return BottomPopupConstants.dismissInteractively }
-    
-    open var popupDimmingViewAlpha: CGFloat { return BottomPopupConstants.kDimmingViewDefaultAlphaValue }
-    
-    open var popupShouldBeganDismiss: Bool { return BottomPopupConstants.shouldBeganDismiss }
-    
-    open var popupViewAccessibilityIdentifier: String { return BottomPopupConstants.defaultPopupViewAccessibilityIdentifier }
-}
-
-extension BottomPopupViewController {
-    open func updatePopupHeight(to height: CGFloat) {
-        transitionHandler?.setHeight(to: height)
-    }
+    // MARK: - BottomPopupAttributesDelegate Variables
+    open var popupHeight: CGFloat { BottomPopupConstants.defaultHeight }
+    open var popupTopCornerRadius: CGFloat { BottomPopupConstants.defaultTopCornerRadius }
+    open var popupPresentDuration: Double { BottomPopupConstants.defaultPresentDuration }
+    open var popupDismissDuration: Double { BottomPopupConstants.defaultDismissDuration }
+    open var popupShouldDismissInteractivelty: Bool { BottomPopupConstants.dismissInteractively }
+    open var popupDimmingViewAlpha: CGFloat { BottomPopupConstants.dimmingViewDefaultAlphaValue }
+    open var popupShouldBeganDismiss: Bool { BottomPopupConstants.shouldBeganDismiss }
+    open var popupViewAccessibilityIdentifier: String { BottomPopupConstants.defaultPopupViewAccessibilityIdentifier }
 }

--- a/BottomPopup/ExampleNavigationController.swift
+++ b/BottomPopup/ExampleNavigationController.swift
@@ -15,18 +15,11 @@ class ExampleNavigationController: BottomPopupNavigationController {
     var dismissDuration: Double?
     var shouldDismissInteractivelty: Bool?
     
-    // Bottom popup attribute variables
-    // You can override the desired variable to change appearance
-    
-    override var popupHeight: CGFloat { return height ?? CGFloat(300) }
-    
-    override var popupTopCornerRadius: CGFloat { return topCornerRadius ?? CGFloat(10) }
-    
-    override var popupPresentDuration: Double { return presentDuration ?? 1.0 }
-    
-    override var popupDismissDuration: Double { return dismissDuration ?? 1.0 }
-    
-    override var popupShouldDismissInteractivelty: Bool { return shouldDismissInteractivelty ?? true }
-    
-    override var popupDimmingViewAlpha: CGFloat { return BottomPopupConstants.kDimmingViewDefaultAlphaValue }
+    // MARK: - BottomPopupAttributesDelegate Variables
+    override var popupHeight: CGFloat { height ?? 300.0 }
+    override var popupTopCornerRadius: CGFloat { topCornerRadius ?? 10.0 }
+    override var popupPresentDuration: Double { presentDuration ?? 1.0 }
+    override var popupDismissDuration: Double { dismissDuration ?? 1.0 }
+    override var popupShouldDismissInteractivelty: Bool { shouldDismissInteractivelty ?? true }
+    override var popupDimmingViewAlpha: CGFloat { BottomPopupConstants.dimmingViewDefaultAlphaValue }
 }

--- a/BottomPopup/ExamplePopupViewController.swift
+++ b/BottomPopup/ExamplePopupViewController.swift
@@ -9,29 +9,21 @@
 import UIKit
 
 class ExamplePopupViewController: BottomPopupViewController {
-
     var height: CGFloat?
     var topCornerRadius: CGFloat?
     var presentDuration: Double?
     var dismissDuration: Double?
     var shouldDismissInteractivelty: Bool?
-    
+
     @IBAction func dismissButtonTapped(_ sender: UIButton) {
         dismiss(animated: true, completion: nil)
     }
     
-    // Bottom popup attribute variables
-    // You can override the desired variable to change appearance
-    
-    override var popupHeight: CGFloat { return height ?? CGFloat(300) }
-    
-    override var popupTopCornerRadius: CGFloat { return topCornerRadius ?? CGFloat(10) }
-    
-    override var popupPresentDuration: Double { return presentDuration ?? 1.0 }
-    
-    override var popupDismissDuration: Double { return dismissDuration ?? 1.0 }
-    
-    override var popupShouldDismissInteractivelty: Bool { return shouldDismissInteractivelty ?? true }
-    
-    override var popupDimmingViewAlpha: CGFloat { return BottomPopupConstants.kDimmingViewDefaultAlphaValue }
+    // MARK: - BottomPopupAttributesDelegate Variables
+    override var popupHeight: CGFloat { height ?? 300.0 }
+    override var popupTopCornerRadius: CGFloat { topCornerRadius ?? 10.0 }
+    override var popupPresentDuration: Double { presentDuration ?? 1.0 }
+    override var popupDismissDuration: Double { dismissDuration ?? 1.0 }
+    override var popupShouldDismissInteractivelty: Bool { shouldDismissInteractivelty ?? true }
+    override var popupDimmingViewAlpha: CGFloat { BottomPopupConstants.dimmingViewDefaultAlphaValue }
 }

--- a/BottomPopup/ViewController.swift
+++ b/BottomPopup/ViewController.swift
@@ -9,13 +9,11 @@
 import UIKit
 
 class ViewController: UIViewController {
-    
     @IBOutlet weak var heightSlider: UISlider!
     @IBOutlet weak var topCornerRadiusSlider: UISlider!
     @IBOutlet weak var presentDurationSlider: UISlider!
     @IBOutlet weak var dismissDurationSlider: UISlider!
     @IBOutlet weak var dismissInteractivelySwitch: UISwitch!
-    
     @IBOutlet weak var heightLabel: UILabel!
     @IBOutlet weak var topCornerRadiusLabel: UILabel!
     @IBOutlet weak var presentDurationLabel: UILabel!
@@ -79,14 +77,14 @@ class ViewController: UIViewController {
     }
     
     @IBAction func showViewControllerTapped(_ sender: UIButton) {
-        guard let popupVC = storyboard?.instantiateViewController(withIdentifier: "secondVC") as? ExamplePopupViewController else { return }
-        popupVC.height = height
-        popupVC.topCornerRadius = topCornerRadius
-        popupVC.presentDuration = presentDuration
-        popupVC.dismissDuration = dismissDuration
-        popupVC.shouldDismissInteractivelty = dismissInteractivelySwitch.isOn
-        popupVC.popupDelegate = self
-        present(popupVC, animated: true, completion: nil)
+        guard let popupViewController = storyboard?.instantiateViewController(withIdentifier: "secondVC") as? ExamplePopupViewController else { return }
+        popupViewController.height = height
+        popupViewController.topCornerRadius = topCornerRadius
+        popupViewController.presentDuration = presentDuration
+        popupViewController.dismissDuration = dismissDuration
+        popupViewController.shouldDismissInteractivelty = dismissInteractivelySwitch.isOn
+        popupViewController.popupDelegate = self
+        present(popupViewController, animated: true, completion: nil)
     }
     
     @IBAction func showNavigationControllerTapped(_ sender: UIButton) {


### PR DESCRIPTION
`BottomPopupTransitionHandler` was retaining the `BottomPopupPresentationController` and this was causing the memory leak. This issue has been solved on this PR. Also, several classes refactored during this fix.